### PR TITLE
✨ Introduce source file builder

### DIFF
--- a/Bearded.FluentSourceGen.Tests/Bearded.FluentSourceGen.Tests.csproj
+++ b/Bearded.FluentSourceGen.Tests/Bearded.FluentSourceGen.Tests.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Verify.SourceGenerators" Version="1.4.0" />
         <PackageReference Include="Verify.Xunit" Version="16.5.4" />

--- a/Bearded.FluentSourceGen.Tests/Utilities/SourceFileBuilderTests.cs
+++ b/Bearded.FluentSourceGen.Tests/Utilities/SourceFileBuilderTests.cs
@@ -102,4 +102,20 @@ var b = a + 1;
 
         action.Should().Throw<InvalidOperationException>();
     }
+
+    [Fact]
+    public void TrimEndRemovesEmptyLinesLeavingLastNewline()
+    {
+        var result = SourceFileBuilder.NewSourceFileBuilder()
+            .AddEmptyLine()
+            .AddExpression("var a = 1")
+            .AddEmptyLine()
+            .AddEmptyLine()
+            .TrimEnd()
+            .ToSourceString();
+
+        result.Should().Be(@"
+var a = 1
+");
+    }
 }

--- a/Bearded.FluentSourceGen.Tests/Utilities/SourceFileBuilderTests.cs
+++ b/Bearded.FluentSourceGen.Tests/Utilities/SourceFileBuilderTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Bearded.FluentSourceGen.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Bearded.FluentSourceGen.Tests.Utilities;
+
+public sealed class SourceFileBuilderTests
+{
+    [Fact]
+    public void EmptyBuilderOutputsEmptyString()
+    {
+        var result = SourceFileBuilder.NewSourceFileBuilder()
+            .ToSourceString();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuilderOutputsAddedLines()
+    {
+        var result = SourceFileBuilder.NewSourceFileBuilder()
+            .AddExpression("var a = 1;")
+            .AddExpression("var b = a + 1;")
+            .ToSourceString();
+
+        result.Should().Be(@"var a = 1;
+var b = a + 1;
+");
+    }
+
+    [Fact]
+    public void BuilderOutputBlocks()
+    {
+        var result = SourceFileBuilder.NewSourceFileBuilder()
+            .StartBlock("sealed class MyClass")
+            .AddExpression("private int aNumber = 1;")
+            .EndBlock()
+            .ToSourceString();
+
+        result.Should().Be($@"sealed class MyClass
+{{
+    private int aNumber = 1;
+}}
+");
+    }
+
+    [Fact]
+    public void BuilderOutputsNonIndentedEmptyLines()
+    {
+        var result = SourceFileBuilder.NewSourceFileBuilder()
+            .StartBlock("sealed class MyClass")
+            .AddExpression("private int aNumber = 1;")
+            .AddEmptyLine()
+            .AddExpression("public int AProperty => aNumber;")
+            .EndBlock()
+            .ToSourceString();
+
+        result.Should().Be($@"sealed class MyClass
+{{
+    private int aNumber = 1;
+
+    public int AProperty => aNumber;
+}}
+");
+    }
+
+    [Fact]
+    public void BuilderOutputsNestedBlocks()
+    {
+        var result = SourceFileBuilder.NewSourceFileBuilder()
+            .StartBlock("sealed class MyClass")
+            .AddExpression("private readonly int aNumber;")
+            .AddEmptyLine()
+            .StartBlock("public MyClass(int aNumber)")
+            .AddExpression("this.aNumber = aNumber;")
+            .EndBlock()
+            .EndBlock()
+            .ToSourceString();
+
+        result.Should().Be($@"sealed class MyClass
+{{
+    private readonly int aNumber;
+
+    public MyClass(int aNumber)
+    {{
+        this.aNumber = aNumber;
+    }}
+}}
+");
+    }
+
+    [Fact]
+    public void NonClosedBlocksThrowException()
+    {
+        var builder = SourceFileBuilder.NewSourceFileBuilder()
+            .StartBlock("sealed class MyClass")
+            .StartBlock("public MyClass()")
+            .EndBlock();
+
+        Action action = () => builder.ToSourceString();
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/Bearded.FluentSourceGen.Tests/goldens/FieldInjectionTest.NamedFieldsTest.verified.cs
+++ b/Bearded.FluentSourceGen.Tests/goldens/FieldInjectionTest.NamedFieldsTest.verified.cs
@@ -1,11 +1,11 @@
 ﻿class MyClass
 {
-private static Int32 myInt;
-private static String myString;
+    private static Int32 myInt;
+    private static String myString;
 
-public MyClass(Int32 myInt, String myString)
-{
-this.myInt = myInt;
-this.myString = myString;
-}
+    public MyClass(Int32 myInt, String myString)
+    {
+        this.myInt = myInt;
+        this.myString = myString;
+    }
 }

--- a/Bearded.FluentSourceGen/Assembly.cs
+++ b/Bearded.FluentSourceGen/Assembly.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Bearded.FluentSourceGen.Tests")]

--- a/Bearded.FluentSourceGen/Core/ClassBuilder.Source.cs
+++ b/Bearded.FluentSourceGen/Core/ClassBuilder.Source.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Text;
 using Bearded.FluentSourceGen.Utilities;
 
 namespace Bearded.FluentSourceGen;
@@ -8,30 +7,31 @@ public sealed partial class ClassBuilder
 {
     public string ToSourceString()
     {
-        var sb = new StringBuilder();
+        var sb = SourceFileBuilder.NewSourceFileBuilder();
+        AppendSourceToFile(sb);
+        return sb.ToSourceString();
+    }
 
-        // TODO: indentation
-        sb.AppendLine($"class {className}");
-        sb.AppendLine("{");
+    internal void AppendSourceToFile(SourceFileBuilder builder)
+    {
+        builder.StartBlock($"class {className}");
 
         foreach (var fieldLine in fields.Select(toSourceString))
         {
-            sb.AppendLine(fieldLine);
+            builder.AddExpression(fieldLine);
         }
 
-        sb.AppendLine();
+        builder.AddEmptyLine();
 
         foreach (var ctor in constructors)
         {
-            sb.Append(ctor.ToSourceString());
-            sb.AppendLine();
+            ctor.AppendSourceToFile(builder);
+            builder.AddEmptyLine();
         }
 
-        sb.TrimEnd();
-        sb.AppendLine();
-        sb.AppendLine("}");
-
-        return sb.ToString();
+        builder
+            .TrimEnd()
+            .EndBlock();
     }
 
     private static string toSourceString(IFieldReference fieldReference)

--- a/Bearded.FluentSourceGen/Core/MethodBuilderBase.Source.cs
+++ b/Bearded.FluentSourceGen/Core/MethodBuilderBase.Source.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using Bearded.FluentSourceGen.Utilities;
 
 namespace Bearded.FluentSourceGen;
 
@@ -9,25 +10,21 @@ public abstract partial class MethodBuilderBase<TMethodBuilder>
 
     public string ToSourceString()
     {
-        var sb = new StringBuilder();
+        var sb = SourceFileBuilder.NewSourceFileBuilder();
+        AppendSourceToFile(sb);
+        return sb.ToSourceString();
+    }
 
-        sb.Append(ToSignatureString());
-        sb.Append('(');
+    internal void AppendSourceToFile(SourceFileBuilder builder)
+    {
+        var parameterString = string.Join(", ", parameters.Select(p => $"{p.Type.Name} {p.Name}"));
+        var fullSignatureString = $"{ToSignatureString()}({parameterString})";
 
-        sb.AppendJoin(", ", parameters.Select(p => $"{p.Type.Name} {p.Name}"));
-
-        sb.Append(')');
-        sb.AppendLine();
-        // TODO: indentation
-        sb.AppendLine("{");
-
+        builder.StartBlock(fullSignatureString);
         foreach (var sourceExpression in expressions)
         {
-            sb.AppendLine(sourceExpression.ToSourceString());
+            builder.AddExpression(sourceExpression.ToSourceString());
         }
-
-        sb.AppendLine("}");
-
-        return sb.ToString();
+        builder.EndBlock();
     }
 }

--- a/Bearded.FluentSourceGen/Utilities/SourceFileBuilder.cs
+++ b/Bearded.FluentSourceGen/Utilities/SourceFileBuilder.cs
@@ -11,7 +11,7 @@ sealed class SourceFileBuilder
     private readonly StringBuilder sb = new();
     private string currentIndentation = "";
 
-    public static SourceFileBuilder NewSourceFileBuilder() => new SourceFileBuilder();
+    public static SourceFileBuilder NewSourceFileBuilder() => new();
 
     private SourceFileBuilder() {}
 
@@ -52,6 +52,13 @@ sealed class SourceFileBuilder
     {
         sb.Append(currentIndentation);
         sb.AppendLine(line);
+        return this;
+    }
+
+    public SourceFileBuilder TrimEnd()
+    {
+        sb.TrimEnd();
+        sb.AppendLine();
         return this;
     }
 

--- a/Bearded.FluentSourceGen/Utilities/SourceFileBuilder.cs
+++ b/Bearded.FluentSourceGen/Utilities/SourceFileBuilder.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+
+namespace Bearded.FluentSourceGen.Utilities;
+
+sealed class SourceFileBuilder
+{
+    private const int indentationSize = 4;
+
+    private readonly StringBuilder sb = new();
+    private string currentIndentation = "";
+
+    public static SourceFileBuilder NewSourceFileBuilder() => new SourceFileBuilder();
+
+    private SourceFileBuilder() {}
+
+    public SourceFileBuilder AddExpression(string expression)
+    {
+        return addLine(expression);
+    }
+
+    public SourceFileBuilder AddEmptyLine()
+    {
+        sb.AppendLine();
+        return this;
+    }
+
+    public SourceFileBuilder StartBlock(string declaration)
+    {
+        return addLine(declaration).addLine("{").indent();
+    }
+
+    public SourceFileBuilder EndBlock()
+    {
+        return unIndent().addLine("}");
+    }
+
+    private SourceFileBuilder indent()
+    {
+        currentIndentation += string.Join("", Enumerable.Range(0, indentationSize).Select(_ => " "));
+        return this;
+    }
+
+    private SourceFileBuilder unIndent()
+    {
+        currentIndentation = currentIndentation[indentationSize..];
+        return this;
+    }
+
+    private SourceFileBuilder addLine(string line)
+    {
+        sb.Append(currentIndentation);
+        sb.AppendLine(line);
+        return this;
+    }
+
+    public string ToSourceString()
+    {
+        if (currentIndentation != string.Empty)
+        {
+            throw new InvalidOperationException("Cannot generate source string with non-closed blocks");
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## ✨ What's this?
This PR adds a source file builder helper class that is used as intermediate helper to generate the source strings.

## 🔍 Why do we want this?
This class tracks things like indentation to make it easier to generate valid source.

In the future we will expand this class to accept a style settings object, so that you can customise things like indentation style, indentation size, and other common style choices. This may in the end lead to the source file generator becoming smarter.

## 🏗 How is it done?
A new class is added.

### 🔬 Why not another way?
One choice I considered is to introduce an "intermediate source" concept. The reason for that being that we have methods generating their own source, which we then need to fit into the indentation of the parent object. Having some sort of instruction set being returned (with, for example, instructions "start block" and "end block") means that we could first pass through all objects making intermediate source, before turning it into strings with actual indentation. This is surely much better than generating a string, and then inserting spaces/tabs to fix the indentation afterwards.

The solution I picked in the end was to just pass in the existing source builder and let the method builder populate it.

We may reconsider depending on how complex this part of the code becomes.

These methods are purposefully internal though so we can trivially review this pattern without breaking public changes.

### 🦋 Side effects
The output source files are now correctly indented.