### PR TITLE
👷‍♂️ Use community reusable workflows

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - ignore-for-release
+    authors:
+      - dependabot
+      - octocat
+  categories:
+    - title: 💥 Breaking changes
+      labels:
+        - breaking-change
+    - title: ✨ New features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bugfixes
+      labels:
+        - bug
+        - fix
+    - title: 📝 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,29 +1,11 @@
-name: Build & Test
+name: Build .NET
 
 on:
   push:
-    branches: [ main ]
+    branches: [ $default-branch ]
   pull_request:
-    branches: [ main ]
+    branches: [ $default-branch ]
 
 jobs:
-  build:
-
-    name: Build & Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            3.1.x
-            5.0.x
-            6.0.x
-      - name: Install dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
+  dotnet-build:
+    uses: beardgame/.github/.github/workflows/dotnet-build.yml@main

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -2,9 +2,9 @@ name: Build .NET
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
 
 jobs:
   dotnet-build:

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,0 +1,13 @@
+name: Publish .NET
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  dotnet-publish:
+    uses: beardgame/.github/.github/workflows/dotnet-publish.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
## ✨ What's this?
Switches to use workflows from the organization .github repository.

## 🔍 Why do we want this?
Saves on maintenance when we make workflows changes across the organization.

## 🏗 How is it done?
Copied the workflow templates.