### PR TITLE
2️⃣ Add netstandard2.0 support

### DIFF
--- a/Bearded.FluentSourceGen.Tests/Bearded.FluentSourceGen.Tests.csproj
+++ b/Bearded.FluentSourceGen.Tests/Bearded.FluentSourceGen.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
@@ -28,6 +28,13 @@
 
     <ItemGroup>
         <Compile Remove="goldens/*.cs" />
+        <Compile Remove="ModuleInitializer.cs" />
+    </ItemGroup>
+
+    <!-- Hacks to make netstandard more usable -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+        <!-- Needed to make module initializers work -->
+        <Compile Include="ModuleInitializer.cs" />
     </ItemGroup>
 
 </Project>

--- a/Bearded.FluentSourceGen.Tests/ModuleInitializer.cs
+++ b/Bearded.FluentSourceGen.Tests/ModuleInitializer.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
+
+namespace System.Runtime.CompilerServices
+{
+    // HACK: Needed to make ModuleInitializer work
+    [ExcludeFromCodeCoverage]
+    [DebuggerNonUserCode]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class ModuleInitializerAttribute : Attribute { }
+}

--- a/Bearded.FluentSourceGen/Bearded.FluentSourceGen.csproj
+++ b/Bearded.FluentSourceGen/Bearded.FluentSourceGen.csproj
@@ -1,8 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
 
+	<ItemGroup>
+		<Compile Remove="IsExternalInit.cs" />
+	</ItemGroup>
+
+	<!-- Hacks to make netstandard more usable -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <!-- Needed to make indexes work -->
+        <PackageReference Include="IndexRange" Version="1.0.2" />
+        <!-- Needed to make C#9 features work -->
+        <Compile Include="IsExternalInit.cs" />
+    </ItemGroup>
 </Project>

--- a/Bearded.FluentSourceGen/IsExternalInit.cs
+++ b/Bearded.FluentSourceGen/IsExternalInit.cs
@@ -1,0 +1,5 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    // HACK: This is needed in order to use C#9+ features in netstandard
+    public class IsExternalInit { }
+}


### PR DESCRIPTION
<!-- This template is a guideline; use your own judgement to write a description that is easy to read and will help get the PR reviewed quickly and accurately -->

<!-- Please add a short, clear title that states what this PR changes -->
<!-- Tag your PR with all of the following tags that are relevant:
  * `fix` if your PR includes a fix for unintentional behavior;
  * `feature` if your PR includes new functionality;
  * `breaking-change` if your PR includes a change that may break existing clients;
  * `ignore-for-release` if your PR should not be included in release notes (for example if it's exclusively related to maintenance and/or CI).
If one of these tags is not available, contact somebody from the beardgame/owners team.
-->

## ✨ What's this?
<!-- Describe clearly and concisely what this PR changes -->
This adds netstandard2.0 support

## 🔍 Why do we want this?
<!-- Describe the reason for making this change -->
In order to consume this library in targets older than net6.0

## 🏗 How is it done?
Adding an extra target + a couple of dependencies because the existing code was too modern

### 💥 Breaking changes
I wonder if this will break releasing. Even if it doesn't, I wonder if releasing will automatically get the netstandard binaries out. If it doesn't, this can be fixed in another PR.
