### PR TITLE
🪓 Add non-generic fields and properties

### DIFF
--- a/Bearded.FluentSourceGen/Core/BuiltField.cs
+++ b/Bearded.FluentSourceGen/Core/BuiltField.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Bearded.FluentSourceGen;
 
 sealed record BuiltField<T>(string Name, MemberVisibility Visibility)
@@ -5,4 +7,11 @@ sealed record BuiltField<T>(string Name, MemberVisibility Visibility)
         IBuiltField
 {
     public FieldReference<T> Reference => new(Name);
+}
+
+sealed record BuiltField(string Name, Type Type, MemberVisibility Visibility)
+    : BuiltMember(Name, Type, Visibility),
+        IBuiltField
+{
+    public FieldReference Reference => new(Name, Type);
 }

--- a/Bearded.FluentSourceGen/Core/BuiltMember.cs
+++ b/Bearded.FluentSourceGen/Core/BuiltMember.cs
@@ -2,7 +2,6 @@ using System;
 
 namespace Bearded.FluentSourceGen;
 
-abstract record BuiltMember<T>(string Name, MemberVisibility Visibility) : IBuiltMember
-{
-    public Type Type => typeof(T);
-}
+abstract record BuiltMember<T>(string Name, MemberVisibility Visibility) : BuiltMember(Name, typeof(T), Visibility);
+
+abstract record BuiltMember(string Name, Type Type, MemberVisibility Visibility) : IBuiltMember;

--- a/Bearded.FluentSourceGen/Core/BuiltProperty.cs
+++ b/Bearded.FluentSourceGen/Core/BuiltProperty.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Bearded.FluentSourceGen;
 
 sealed record BuiltProperty<T>(string Name, MemberVisibility Visibility, FieldReference<T> FieldReference)
@@ -5,5 +7,13 @@ sealed record BuiltProperty<T>(string Name, MemberVisibility Visibility, FieldRe
         IBuiltProperty
 {
     public PropertyReference<T> Reference => new(Name);
+    public IFieldReference WrappedField => FieldReference;
+}
+
+sealed record BuiltProperty(string Name, Type Type, MemberVisibility Visibility, FieldReference FieldReference)
+    : BuiltMember(Name, Type, Visibility),
+        IBuiltProperty
+{
+    public PropertyReference Reference => new(Name, Type);
     public IFieldReference WrappedField => FieldReference;
 }

--- a/Bearded.FluentSourceGen/Core/ClassBuilder.Fields.cs
+++ b/Bearded.FluentSourceGen/Core/ClassBuilder.Fields.cs
@@ -24,6 +24,17 @@ public sealed partial class ClassBuilder
         return this;
     }
 
+    public ClassBuilder AddField(
+        string name, Type type, Func<FieldBuilder, FieldBuilder> builderFunc, out FieldReference fieldReference)
+    {
+        var builder = FieldBuilder.NewFieldBuilder(name, type);
+        builder = builderFunc(builder);
+        var built = builder.Build();
+        fields.Add(built);
+        fieldReference = built.Reference;
+        return this;
+    }
+
     public ClassBuilder AddAutoGetter<T>(
         string name,
         MemberVisibility visibility,

--- a/Bearded.FluentSourceGen/Core/ClassBuilder.cs
+++ b/Bearded.FluentSourceGen/Core/ClassBuilder.cs
@@ -4,7 +4,7 @@ public sealed partial class ClassBuilder
 {
     public static ClassBuilder NewClassBuilder(string name)
     {
-        return new(name);
+        return new ClassBuilder(name);
     }
 
     private readonly string className;

--- a/Bearded.FluentSourceGen/Core/ConstructorBuilder.FieldInjection.cs
+++ b/Bearded.FluentSourceGen/Core/ConstructorBuilder.FieldInjection.cs
@@ -6,7 +6,7 @@ public sealed partial class ConstructorBuilder
     {
         foreach (var field in fields)
         {
-            AddParameter(field.Type, field.Name, out var parameterReference);
+            AddParameter(field.Name, field.Type, out var parameterReference);
             // TODO: this shouldn't be string-based
             AddExpression(SourceExpression.FromSource($"this.{field.Name} = {parameterReference.Name};"));
         }

--- a/Bearded.FluentSourceGen/Core/FieldBuilder.cs
+++ b/Bearded.FluentSourceGen/Core/FieldBuilder.cs
@@ -1,29 +1,39 @@
+using System;
+
 namespace Bearded.FluentSourceGen;
 
-public sealed class FieldBuilder<T>
+public sealed class FieldBuilder<T> : FieldBuilderImplementation<FieldBuilder<T>>
 {
-    private readonly string name;
-    private MemberVisibility visibility = MemberVisibility.Private;
+    protected override FieldBuilder<T> This => this;
 
-    internal FieldBuilder(string name)
-    {
-        this.name = name;
-    }
-
-    public FieldBuilder<T> WithVisibility(MemberVisibility visibility)
-    {
-        this.visibility = visibility;
-        return this;
-    }
+    internal FieldBuilder(string name) : base(name) { }
 
     internal BuiltField<T> Build()
     {
-        return new BuiltField<T>(name, visibility);
+        return new BuiltField<T>(Name, Visibility);
     }
 }
 
-public static class FieldBuilder
+public sealed class FieldBuilder : FieldBuilderImplementation<FieldBuilder>
 {
+    private readonly Type type;
+    protected override FieldBuilder This => this;
+
+    private FieldBuilder(string name, Type type) : base(name)
+    {
+        this.type = type;
+    }
+
+    internal BuiltField Build()
+    {
+        return new BuiltField(Name, type, Visibility);
+    }
+
+    public static FieldBuilder NewFieldBuilder(string name, Type type)
+    {
+        return new FieldBuilder(name, type);
+    }
+
     public static FieldBuilder<T> NewFieldBuilder<T>(string name)
     {
         return new FieldBuilder<T>(name);

--- a/Bearded.FluentSourceGen/Core/FieldBuilderImplementation.cs
+++ b/Bearded.FluentSourceGen/Core/FieldBuilderImplementation.cs
@@ -1,0 +1,21 @@
+namespace Bearded.FluentSourceGen;
+
+public abstract class FieldBuilderImplementation<TFieldBuilder>
+    where TFieldBuilder : FieldBuilderImplementation<TFieldBuilder>
+{
+    protected string Name { get; }
+    protected MemberVisibility Visibility { get; private set; } = MemberVisibility.Private;
+
+    protected abstract TFieldBuilder This { get; }
+
+    protected FieldBuilderImplementation(string name)
+    {
+        Name = name;
+    }
+
+    public TFieldBuilder WithVisibility(MemberVisibility visibility)
+    {
+        Visibility = visibility;
+        return This;
+    }
+}

--- a/Bearded.FluentSourceGen/Core/FieldReference.cs
+++ b/Bearded.FluentSourceGen/Core/FieldReference.cs
@@ -2,13 +2,19 @@ using System;
 
 namespace Bearded.FluentSourceGen;
 
-public sealed class FieldReference<T> : IFieldReference
+public sealed class FieldReference<T> : FieldReference
+{
+    internal FieldReference(string name) : base(name, typeof(T)) { }
+}
+
+public class FieldReference : IFieldReference
 {
     public string Name { get; }
-    public Type Type => typeof(T);
+    public Type Type { get; }
 
-    internal FieldReference(string name)
+    internal FieldReference(string name, Type type)
     {
         Name = name;
+        Type = type;
     }
 }

--- a/Bearded.FluentSourceGen/Core/IBuiltField.cs
+++ b/Bearded.FluentSourceGen/Core/IBuiltField.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Bearded.FluentSourceGen;
 
 interface IBuiltField : IBuiltMember {}

--- a/Bearded.FluentSourceGen/Core/MethodBuilderBase.Parameters.cs
+++ b/Bearded.FluentSourceGen/Core/MethodBuilderBase.Parameters.cs
@@ -14,7 +14,7 @@ public abstract partial class MethodBuilderBase<TMethodBuilder>
         return This;
     }
 
-    public TMethodBuilder AddParameter(Type type, string name, out IParameterReference parameterReference)
+    public TMethodBuilder AddParameter(string name, Type type, out IParameterReference parameterReference)
     {
         parameterReference = new ParameterReference(name, type);
         parameters.Add(parameterReference);

--- a/Bearded.FluentSourceGen/Core/PropertyReference.cs
+++ b/Bearded.FluentSourceGen/Core/PropertyReference.cs
@@ -2,13 +2,19 @@ using System;
 
 namespace Bearded.FluentSourceGen;
 
-public sealed class PropertyReference<T> : IPropertyReference
+public sealed class PropertyReference<T> : PropertyReference
+{
+    internal PropertyReference(string name) : base(name, typeof(T)) { }
+}
+
+public class PropertyReference : IPropertyReference
 {
     public string Name { get; }
-    public Type Type => typeof(T);
+    public Type Type { get; }
 
-    internal PropertyReference(string name)
+    internal PropertyReference(string name, Type type)
     {
         Name = name;
+        Type = type;
     }
 }


### PR DESCRIPTION
## ✨ What's this?
Adds support for fields and properties where the type isn't known ahead of time (e.g. there dynamically generated), so using generics is inconvenient.

### 🔗 Relationships
Closes #9 

## 🔍 Why do we want this?
When writing source generation, sometimes the exact types of the fields and properties (and also things like method return types, though they are not supported right now) isn't known at compile time, so we want to be able to write our code in a way that is agnostic of types at compile-time. For that, we want to avoid using generics.

## 🏗 How is it done?
This PR abstracts away as much logic that doesn't rely on generics into base classes, so that it is easy to support both non-generic and generic versions.

### 💥 Breaking changes
* `AddParameter` on the method builder had its `Name` and `Type` parameters flipped to be consistent across the library.
