### PR TITLE
📝 Add NuGet metadata

### DIFF
--- a/Bearded.FluentSourceGen/Bearded.FluentSourceGen.csproj
+++ b/Bearded.FluentSourceGen/Bearded.FluentSourceGen.csproj
@@ -4,13 +4,18 @@
         <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
+        <AssemblyTitle>Bearded FluentSourceGen</AssemblyTitle>
+        <Description>Allows using C# source generators using a fluent, type safe interface rather than string templating.</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/beardgame/fluentsourcegen</RepositoryUrl>
+        <PackageTags>game-development;gamedev;code-generation;source-generation;csharp-sourcegenerator;roslyn-generator</PackageTags>
     </PropertyGroup>
 
-	<ItemGroup>
-		<Compile Remove="IsExternalInit.cs" />
-	</ItemGroup>
+    <ItemGroup>
+        <Compile Remove="IsExternalInit.cs" />
+    </ItemGroup>
 
-	<!-- Hacks to make netstandard more usable -->
+    <!-- Hacks to make netstandard more usable -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <!-- Needed to make indexes work -->
         <PackageReference Include="IndexRange" Version="1.0.2" />


### PR DESCRIPTION
## ✨ What's this?
Add some metadata for the NuGet gallery (https://www.nuget.org/packages/Bearded.FluentSourceGen).
Specifically, a link back to the github repo, a MIT licence and a good description.

## 🔍 Why do we want this?
More clarity for people using the NuGet gallery.

## 🏗 How is it done?
Mostly moving metadata from the (no longer used) nuspec file to the project file, as is the best practice these days (https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices).

### 🔬 Why not another way?
It's best practice these days to use the project file instead of nuspec files (which you weren't using anymore anyways).

### 🦋 Side effects
Maybe the tags aren't up to date anymore - I left out some tags from the repository, as they seem a bit overly broad.
The csproj file used a mix of both tabs and spaces - I converted all tabs to spaces as well in the process.
